### PR TITLE
Resolve URL convention

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: node_js
+node_js:
+    - node
+
+cache:
+    directories:
+        - node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,13 +8,15 @@ ENV LAST_UPDATE 2016-09-30
 ENV CURIOUS_JS_DIR /usr/src/curious-js
 WORKDIR $CURIOUS_JS_DIR
 
-# Set Chrome script to run in non-sandbox mode
 COPY package.json .
 RUN npm install
 
 COPY curious.js .
 COPY scripts ./scripts
 COPY tests ./tests
+
+# Development files
+COPY .eslintrc.yaml .
 
 ENTRYPOINT ["npm", "run"]
 CMD ["test"]

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 JavaScript consumer code for Curious APIs.
 
+[![Build Status](https://travis-ci.org/ginkgobioworks/curious-js.svg?branch=master)](https://travis-ci.org/ginkgobioworks/curious-js)
+
 ## Usage
 
 ### Installation

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # curious-js
 
-JavaScript consumer code for Curious APIs.
-
-[![Build Status](https://travis-ci.org/ginkgobioworks/curious-js.svg?branch=master)](https://travis-ci.org/ginkgobioworks/curious-js)
+JavaScript consumer code for Curious APIs. [![Build Status](https://travis-ci.org/ginkgobioworks/curious-js.svg?branch=v2)](https://travis-ci.org/ginkgobioworks/curious-js)
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -20,23 +20,33 @@ default name `curious`) in whatever system you are using.
 There are two main parts to using Curious from Javascript: `CuriousClient`,
 and `CuriousQuery`.
 
-First, create an instance of `CuriousClient` that points to your Curious server. You are responsible
-for picking and using a request method that works for you. `CuriousClient` provides some convenience
-wrappers, but you can make any asynchronous transport layer work by passing a custom function as the
-second parameter to the client constructor. Note that if you're using jQuery, `jQuery.post` does not
-require any wrapping and can be passed as the second parameter directly.
+First, create an instance of `CuriousClient` that points to your Curious server, providing a
+server URL and a request function.
+
+_The server URL provided to the client should point to the Curious root endpoint, **not** to the
+query endpoint (`/q/`)on the server_. The code will not break if you make this mistake, but the
+behavior is deprecated.
+
+You must also provide a request method. You are responsible for picking and using a request
+method/transport layer that works for you. `CuriousClient` provides convenience wrappers for
+common request methods, but you can make any asynchronous transport layer work by passing a custom
+function as the second parameter to the client constructor. The function must take the URL as its
+first parameter and an object payload as its second parameter, make a `POST` request to the curious
+server, and return a Promise (or any thenable) that resolves to the JSON data returned by the
+server. Note that if you're using jQuery, `jQuery.post` does not require any wrapping and can be
+passed as the second parameter directly.
 
 ```javascript
-// example using Axios
+// Example using Axios
 var curiousClient = new curious.CuriousClient(CURIOUS_URL, curious.CuriousClient.wrappers.axios(axios), ...);
 
-// example using a custom request method
+// Example using a custom request method
 var curiousClient = new curious.CuriousClient(CURIOUS_URL, function (url, data) {
   return new Promise(function (resolve, reject) {
     var result;
     var error;
 
-    // perform some asynchronous access
+    // Perform some asynchronous access
 
     if (error) {
       reject(error);
@@ -50,7 +60,7 @@ var curiousClient = new curious.CuriousClient(CURIOUS_URL, function (url, data) 
 Then, construct a `CuriousQuery` and perform it on the server using the client. Attach any callbacks
 to the Promise object returned by the `perform` method, or directly to the query object. They will
 be executed in the order they were attached, before any callbacks attached later. The results of the
-query will be passed to the callback.
+query will be passed to the first callback.
 
 Here's a trivial example. The results, of course, depend on the schema on the Curious server; the
 example uses a made up schema consiting of Document and Section entities in a 1:many relationship.
@@ -229,14 +239,37 @@ CuriousObject {
        sections: [Object] } ] }
 ```
 
-The API is explained in detail in  the documentation.
+The API is explained in detail in the documentation.
 
 ## Development
 
-This project provides a basic Dockerfile that builds a Docker container capable of running unit
-tests. To run the tests, bring up the container with `docker-compose up`.
+Development is carried out through an included Docker environment.
+
+### Docker
+
+The project provides a Dockerfile that builds a container capable of running the unit tests and
+scripts. To run the tests, bring up the container with `docker-compose up`. Any of the scripts shown
+to be run below from a shell with `npm run` can be executed in an instance of the container with
+`docker-compose run --rm [script name]`.
+
+### REPL
+
+A script that opens up a node.js REPL and loads curious.js as `curious` is provided with
+`npm run repl`.
 
 ### Test framework
 
 The tests are written in [mocha](https://mochajs.org/), with [chai](http://chaijs.com/) expect-style
-assertions.
+assertions. Tests can be run with `npm test`.
+
+Coding conventions and linting are enforced at the unit test level, but can also be run
+independently with `npm run lint`.
+
+### Documentation
+
+Any new code added to `curious.js` must be documented in a manner consistent with existing
+documentation.
+
+JSDoc documentation can be generated into the `doc/` subdirectory from the source code and README
+with `npm run make_doc`. It can be updated on the project website automatically with `npm run
+release_doc`.

--- a/curious.js
+++ b/curious.js
@@ -649,7 +649,7 @@
       } else if (thenPair.length > 1 && thenPair[1]) {
         // If the first callback is null but the second one isn't, we're looking at a catch
         // situation. We use the same data structure to store both situations, so that they're
-        // attached to the proise in the same order they were attached to the Query object
+        // attached to the promise in the same order they were attached to the Query object
         promise = promise.catch(thenPair[1]);
       }
     });

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
       context: .
       dockerfile: Dockerfile
     volumes:
+      - ./.eslintrc.yaml:/usr/src/curious-js/.eslintrc.yaml
       - ./curious.js:/usr/src/curious-js/curious.js
       - ./scripts:/usr/src/curious-js/scripts
       - ./tests:/usr/src/curious-js/tests

--- a/package.json
+++ b/package.json
@@ -37,13 +37,16 @@
     "repl": "./scripts/repl",
     "test": "./scripts/run_tests"
   },
-  "dependencies": {
-  },
+  "dependencies": {},
   "devDependencies": {
     "axios": "~0.5.4",
+    "babel-eslint": "^7.1.1",
     "chai": "~2.3.0",
+    "eslint-config-airbnb-es5": "^1.1.0",
+    "eslint-plugin-react": "^6.7.1",
     "jsdoc": "~3.3.0",
-    "mocha": "~2.2.5"
+    "mocha": "~2.2.5",
+    "mocha-eslint": "^3.0.1"
   },
   "engines": {
     "node": ">=0.10.0"

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   ],
   "main": "./curious.js",
   "scripts": {
+    "lint": "./scripts/lint",
     "make_doc": "./scripts/make_doc",
     "prepublish": "./scripts/make_doc",
     "release_doc": "./scripts/release_doc",

--- a/scripts/lint
+++ b/scripts/lint
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+
+# lint - run ESLint on the code
+
+cd "`dirname $0`/.."
+
+./node_modules/.bin/eslint "$@" curious.js tests && echo OK
+
+cd - 1>/dev/null

--- a/scripts/make_doc
+++ b/scripts/make_doc
@@ -1,4 +1,6 @@
-#!/bin/bash -e -x
+#!/bin/bash
+set -e
+set -x
 
 # make_doc - generate JSDoc for the project
 

--- a/tests/curious_client.js
+++ b/tests/curious_client.js
@@ -23,6 +23,57 @@
       srv.close(done);
     });
 
+    describe('#queryUrl', function () {
+      function _queryUrl(baseUrl) { return new curious.CuriousClient(baseUrl).queryUrl; }
+
+      it('should add "/q/" to url paths', function () {
+        expect(_queryUrl('foobar.com/curious')).to.equal('foobar.com/curious/q/');
+        expect(_queryUrl('foobar.com/curious/')).to.equal('foobar.com/curious/q/');
+      });
+
+      it('should add "/q/" to server urls', function () {
+        expect(_queryUrl('curious.foobar.com')).to.equal('curious.foobar.com/q/');
+        expect(_queryUrl('curious.foobar.com/')).to.equal('curious.foobar.com/q/');
+      });
+
+      it('should add "/q/" to local urls', function () {
+        expect(_queryUrl('curious/')).to.equal('curious/q/');
+        expect(_queryUrl('curious')).to.equal('curious/q/');
+        expect(_queryUrl('/curious/')).to.equal('/curious/q/');
+        expect(_queryUrl('/curious')).to.equal('/curious/q/');
+      });
+
+      it('should add "/q/" to empty urls', function () {
+        expect(_queryUrl('')).to.equal('/q/');
+        expect(_queryUrl('/')).to.equal('/q/');
+        expect(_queryUrl('//')).to.equal('//q/');
+      });
+
+      it('should not add extra "/q/"s to url paths', function () {
+        expect(_queryUrl('foobar.com/curious/q')).to.equal('foobar.com/curious/q/');
+        expect(_queryUrl('foobar.com/curious/q/')).to.equal('foobar.com/curious/q/');
+      });
+
+      it('should not add extra "/q/"s to server urls', function () {
+        expect(_queryUrl('curious.foobar.com/q')).to.equal('curious.foobar.com/q/');
+        expect(_queryUrl('curious.foobar.com/q/')).to.equal('curious.foobar.com/q/');
+      });
+
+      it('should not add extra "/q/"s to local urls', function () {
+        expect(_queryUrl('curious/')).to.equal('curious/q/');
+        expect(_queryUrl('curious')).to.equal('curious/q/');
+        expect(_queryUrl('/curious/')).to.equal('/curious/q/');
+        expect(_queryUrl('/curious')).to.equal('/curious/q/');
+      });
+
+      it('should not add extra "/q/" to "q" urls', function () {
+        expect(_queryUrl('/q')).to.equal('/q/');
+        expect(_queryUrl('/q/')).to.equal('/q/');
+        expect(_queryUrl('//q')).to.equal('//q/');
+        expect(_queryUrl('//q/')).to.equal('//q/');
+      });
+    });
+
     describe('#performQuery', function () {
       it('should work with axios', function (done) {
         var requestFunctions;

--- a/tests/eslint.js
+++ b/tests/eslint.js
@@ -1,0 +1,12 @@
+/* global describe it before beforeEach after */
+
+// mocha.js tests for the functions dealing with Curious queries
+(function () {
+  'use strict';
+  var lint = require('mocha-eslint');
+
+  lint([
+    'curious.js',
+    'tests',
+  ]);
+}());

--- a/tests/server.js
+++ b/tests/server.js
@@ -9,7 +9,7 @@
   var examples = require('./examples.js');
 
   var PORT = 8080;
-  var CURIOUS_URL = 'http://localhost:' + PORT;
+  var URL = 'http://localhost:' + PORT;
 
   function start(cb) {
     var server;
@@ -28,7 +28,7 @@
   }
 
   module.exports = {
-    url: CURIOUS_URL,
+    url: URL,
     start: start,
   };
 


### PR DESCRIPTION
Some of the code that uses curious.js has inconsistent interpretations of what URL should be associated with the curious server. Sometimes, two variables with the same name will point at different URLs: one will point to the server itself (`curious.foo.com`)—the base URL, and one will point at the query endpoint (`curious.foo.com/q/`)—the query URL.

Previously, curious.js expected the query URL to be passed in when a `CuriousClient` object was created. In order to facilitate consistency between the two different definitions of the curious URL, this patch allows `CuriousClient` objects to be created by passing in the base URL as well; furthermore, _this is now the preferred URL to use_.

Specifically:
- old: `var client = new curious.CuriousClient('curious.foo.com/q/')`
- new: `var client = new curious.CuriousClient('curious.foo.com/')`