### PR TITLE
Fix query cleanup

### DIFF
--- a/curious.js
+++ b/curious.js
@@ -1503,7 +1503,7 @@
         }
 
         args = _getArgs(params, clientDefaultArgs);
-        args.q = q.replace('\n', ' ');
+        args.q = q.replace(/\n+/g, ' ');
 
         return request(this.queryUrl, args)
           .then(function (response) {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "axios": "~0.5.4",
     "babel-eslint": "^7.1.1",
     "chai": "~2.3.0",
+    "es6-promise": "^4.0.5",
     "eslint-config-airbnb-es5": "^1.1.0",
     "eslint-plugin-react": "^6.7.1",
     "jsdoc": "~3.3.0",

--- a/tests/curious_client.js
+++ b/tests/curious_client.js
@@ -9,6 +9,7 @@
   var curious = require('../curious.js');
   var examples = require('./examples.js');
   var server = require('./server.js');
+  var Promise = require('es6-promise');
 
   // TESTS
 
@@ -75,6 +76,41 @@
     });
 
     describe('#performQuery', function () {
+      it('should remove all line breaks', function () {
+        // Encapsulate logic for testing query processing
+        function testQueryString(original, expected) {
+          // Fake request function that tests whether or not the arguments are what we expect
+          function fakeRequest(url, args) {
+            expect(args.q).to.equal(expected);
+
+            // Must resolve to an object with a 'result' property to prevent errors in parsing
+            return Promise.resolve({ result: args });
+          }
+
+          return new curious.CuriousClient(server.url, fakeRequest, null, true).performQuery(original);
+        }
+
+        return Promise.all([
+          testQueryString('no breaks', 'no breaks'),
+          testQueryString(
+            'break\nin the middle',
+            'break in the middle'
+          ),
+          testQueryString(
+            'multiple\nbreaks\nin the middle',
+            'multiple breaks in the middle'
+          ),
+          testQueryString(
+            '\nmultiple\nbreaks\nin the middle and edges\n',
+            ' multiple breaks in the middle and edges '
+          ),
+          testQueryString(
+            'multiple\nbreaks\n\nin a row',
+            'multiple breaks in a row'
+          ),
+        ]);
+      });
+
       it('should work with axios', function (done) {
         var requestFunctions;
         // Set the global axios variable to test axios wrapper defaults


### PR DESCRIPTION
Line breaks were not properly being removed: global replace
must use a regexp, not a plain string