### PR TITLE
Remove CommonJS call that rollup does for us

### DIFF
--- a/curious.js
+++ b/curious.js
@@ -1,4 +1,3 @@
-/* global define */
 /**
  * curious.js - JavaScript consumer code for Curious APIs.
  *
@@ -11,11 +10,6 @@
   *
   * @module curious
   */
-
-'use strict';
-
-// For node.js and CommonJS
-Object.defineProperty(exports, '__esModule', { value: true });
 
 // QUERY TERMS
 


### PR DESCRIPTION
Rollup.js adds the removed snippet for us in CommonJS builds, and leaving it in may break ES6 modules in browser environments in the future.